### PR TITLE
tap-id: Add detection for element outside viewport

### DIFF
--- a/src/util/decode.h
+++ b/src/util/decode.h
@@ -16,4 +16,14 @@
  */
 char *decode_extract_response_value(const char *msg, size_t len);
 
+/**
+ * Extract the integer value from a response.
+ *
+ * \param[in]  msg  The message to extract a value from.
+ * \param[in]  len  The length of the message to extract.
+ * \param[out] ret  Returns an integer on success.
+ * \return Returns true on success of false on error.
+ */
+bool decode_extract_response_value_int(const char *msg, size_t len, int *ret);
+
 #endif


### PR DESCRIPTION
Detects when the element of given ID is outside the viewport and reports.